### PR TITLE
removed unsupported docker layer caching due to free plan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,7 @@ jobs:
       - image: cimg/node:12.0.0
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - attach_workspace:
           at: /tmp/workspace
       - run: |


### PR DESCRIPTION
I removed docker layer caching as it's not supported in free plan. 